### PR TITLE
Fix start line numbers being highlighted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -353,7 +353,7 @@ export default function rehypePrettyCode(
 
         const lineNumbers: number[] = [];
         if (meta) {
-          const matches = meta.matchAll(/\{(.*?)\}/g);
+          const matches = meta.matchAll(/(?<!\S)\{(.*?)\}/g);
           for (const match of matches) {
             if (match[1]) {
               lineNumbers.push(...rangeParser(match[1]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -353,7 +353,7 @@ export default function rehypePrettyCode(
 
         const lineNumbers: number[] = [];
         if (meta) {
-          const matches = meta.matchAll(/(?<!\S)\{(.*?)\}/g);
+          const matches = meta.matchAll(/\B\{(.*?)\}\B/g);
           for (const match of matches) {
             if (match[1]) {
               lineNumbers.push(...rangeParser(match[1]));

--- a/test/fixtures/highlightedLinesWithShowLineNumbersAt.md
+++ b/test/fixtures/highlightedLinesWithShowLineNumbersAt.md
@@ -27,3 +27,45 @@ const subtract = (x, y) => x - y;
 
 const multiply = (x, y) => x * y;
 ```
+
+showLineNumbers{3} {2,4-5}
+
+```js showLineNumbers{3} {2,4-5}
+// should not be highlighted
+// should be highlighted
+// should not be highlighted
+// should be highlighted
+// should be highlighted
+// should not be highlighted
+```
+
+{2,4-5} showLineNumbers{3}
+
+```js {2,4-5} showLineNumbers{3}
+// should not be highlighted
+// should be highlighted
+// should not be highlighted
+// should be highlighted
+// should be highlighted
+// should not be highlighted
+```
+
+showLineNumbers{3} {2-4}
+
+```js showLineNumbers{3} {2-4}
+// should not be highlighted
+// should be highlighted
+// should be highlighted
+// should be highlighted
+// should not be highlighted
+```
+
+{2-4} showLineNumbers{3}
+
+```js {2-4} showLineNumbers{3}
+// should not be highlighted
+// should be highlighted
+// should be highlighted
+// should be highlighted
+// should not be highlighted
+```

--- a/test/results/highlightedLinesWithShowLineNumbersAt.html
+++ b/test/results/highlightedLinesWithShowLineNumbersAt.html
@@ -86,3 +86,57 @@
 <span class="highlighted" data-line="" data-highlighted-line=""> </span>
 <span data-line=""><span style="color:#F97583">const</span><span style="color:#B392F0"> multiply</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> (</span><span style="color:#FFAB70">x</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">y</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">=></span><span style="color:#E1E4E8"> x </span><span style="color:#F97583">*</span><span style="color:#E1E4E8"> y;</span></span></code></pre>
 </figure>
+<p>showLineNumbers{3} {2,4-5}</p>
+<figure data-rehype-pretty-code-figure="">
+  <pre
+    style="background-color: #24292e; color: #e1e4e8"
+    tabindex="0"
+    data-language="js"
+    data-theme="github-dark"
+  ><code data-line-numbers="" style="counter-set: line 2;display: grid;" data-language="js" data-theme="github-dark" data-line-numbers-max-digits="1"><span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span></code></pre>
+</figure>
+<p>{2,4-5} showLineNumbers{3}</p>
+<figure data-rehype-pretty-code-figure="">
+  <pre
+    style="background-color: #24292e; color: #e1e4e8"
+    tabindex="0"
+    data-language="js"
+    data-theme="github-dark"
+  ><code data-line-numbers="" style="counter-set: line 2;display: grid;" data-language="js" data-theme="github-dark" data-line-numbers-max-digits="1"><span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span></code></pre>
+</figure>
+<p>showLineNumbers{3} {2-4}</p>
+<figure data-rehype-pretty-code-figure="">
+  <pre
+    style="background-color: #24292e; color: #e1e4e8"
+    tabindex="0"
+    data-language="js"
+    data-theme="github-dark"
+  ><code data-line-numbers="" style="counter-set: line 2;display: grid;" data-language="js" data-theme="github-dark" data-line-numbers-max-digits="1"><span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span></code></pre>
+</figure>
+<p>{2-4} showLineNumbers{3}</p>
+<figure data-rehype-pretty-code-figure="">
+  <pre
+    style="background-color: #24292e; color: #e1e4e8"
+    tabindex="0"
+    data-language="js"
+    data-theme="github-dark"
+  ><code data-line-numbers="" style="counter-set: line 2;display: grid;" data-language="js" data-theme="github-dark" data-line-numbers-max-digits="1"><span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span class="highlighted" data-line="" data-highlighted-line=""><span style="color:#6A737D">// should be highlighted</span></span>
+<span data-line=""><span style="color:#6A737D">// should not be highlighted</span></span></code></pre>
+</figure>


### PR DESCRIPTION
This PR fixes an issue where combining `showLineNumbers{number}` with line highlighting would cause the start line number to be highlighted when it shouldn't be.

Included is an expanded test fixture that demonstrates the issue, which can be fixed by using a negative lookbehind in the regex used to find highlighted line numbers in the meta.

**Before this PR:**

<img width="801" alt="Screenshot 2024-02-17 at 15 07 02" src="https://github.com/rehype-pretty/rehype-pretty-code/assets/100152/9642b2c8-0041-42c3-8d4f-b57f1bb1ba29">

**After this PR:**

<img width="801" alt="Screenshot 2024-02-17 at 15 07 16" src="https://github.com/rehype-pretty/rehype-pretty-code/assets/100152/08f2ebc4-a344-4cae-8821-08ffa10f0184">