### PR TITLE
Fixed errors in showLineNumbers example.

### DIFF
--- a/website/src/app/index.mdx
+++ b/website/src/app/index.mdx
@@ -500,11 +500,15 @@ code[data-line-numbers] > [data-line]::before {
 }
 
 code[data-line-numbers-max-digits="2"] > [data-line]::before {
-  width: 2rem;
+  width: 16px;
 }
 
 code[data-line-numbers-max-digits="3"] > [data-line]::before {
-  width: 3rem;
+  width: 28px;
+}
+
+code[data-line-numbers-max-digits="4"] > [data-line]::before {
+  width: 35px;
 }
 ```
 

--- a/website/src/app/index.mdx
+++ b/website/src/app/index.mdx
@@ -483,11 +483,11 @@ Add a caption underneath your code block, with text inside double quotes (`""`):
 CSS counters can be used to add line numbers.
 
 ```css {2,6-7}
-code {
+code[data-line-numbers] {
   counter-reset: line;
 }
 
-code > [data-line]::before {
+code[data-line-numbers] > [data-line]::before {
   counter-increment: line;
   content: counter(line);
 


### PR DESCRIPTION
The example css did not work properly for conditional showLineNumbers.

Used the css from the website that shows the working example.
- Line 45-53 
https://github.com/rehype-pretty/rehype-pretty-code/blob/master/website/src/app/globals.css

Previous sizing of 3rem for 3 digits was too large. Fixed it.
Added size for 4 digits.