### PR TITLE
Change overflow-x from scroll to auto

### DIFF
--- a/examples/astro/src/globals.css
+++ b/examples/astro/src/globals.css
@@ -134,7 +134,7 @@ figure {
 pre,
 code,
 figure {
-  @apply overflow-x-scroll px-2 py-1;
+  @apply overflow-x-auto px-2 py-1;
 }
 p {
   @apply text-xl;

--- a/examples/astro/src/pages/page.astro
+++ b/examples/astro/src/pages/page.astro
@@ -71,7 +71,7 @@ export default defineConfig({
   pre,
   code,
   figure {
-    @apply overflow-x-scroll px-2 py-1;
+    @apply overflow-x-auto px-2 py-1;
   }
   p {
     @apply text-xl;

--- a/examples/sveltekit/src/routes/+page.svelte
+++ b/examples/sveltekit/src/routes/+page.svelte
@@ -26,7 +26,7 @@ export let data: PageData;
   :global(code),
   :global(figure) {
     border-radius: 5px;
-    overflow-x: scroll;
+    overflow-x: auto;
     padding: 5px 6px 6px 6px;
   }
 

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -105,7 +105,7 @@ figure {
 pre,
 code,
 figure {
-  @apply overflow-x-scroll;
+  @apply overflow-x-auto;
 }
 p {
   @apply text-xl;


### PR DESCRIPTION
Resolves #210 

This hides the scrollbar when there is sufficient space, which fixes the layout of the code component on the main website as well as a few examples.

# Screenshots

Main page (Before / After)

<img src="https://github.com/rehype-pretty/rehype-pretty-code/assets/26753734/9f23157c-b462-4fb5-8f8e-2ce8542a54a7" width="300"/>
<img src="https://github.com/rehype-pretty/rehype-pretty-code/assets/26753734/4f3407ae-1d62-4ec4-93bc-4433300de3bf" width="300"/>

Astro Example

<img src="https://github.com/rehype-pretty/rehype-pretty-code/assets/26753734/f934dc30-8dd3-4dea-89a5-2b6d2dce24dc" width="300"/>
<img src="https://github.com/rehype-pretty/rehype-pretty-code/assets/26753734/66279873-261a-4247-b301-2380d318358d" width="300"/>

Svelte Example

<img src="https://github.com/rehype-pretty/rehype-pretty-code/assets/26753734/c9575d35-70ff-4b34-a9e0-b8cc64f2bbb7" width="300"/>
<img src="https://github.com/rehype-pretty/rehype-pretty-code/assets/26753734/820d50a7-0092-44f2-bafc-f4ec32fe408f" width="300"/>