### PR TITLE
Bypass inline code

### DIFF
--- a/.changeset/perfect-onions-dream.md
+++ b/.changeset/perfect-onions-dream.md
@@ -1,0 +1,5 @@
+---
+"rehype-pretty-code": minor
+---
+
+Adds an option to bypass inline code blocks

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -220,6 +220,7 @@ interface Options {
   grid?: boolean;
   theme?: Theme | Record<string, Theme>;
   keepBackground?: boolean;
+  bypassInlineCode?: boolean;
   defaultLang?: string | { block?: string; inline?: string };
   tokensMap?: Record<string, string>;
   transformers?: ShikiTransformer[];
@@ -274,6 +275,16 @@ theme:
 ```js
 const options = {
   keepBackground: false,
+};
+```
+
+### `bypassInlineCode`
+
+Skip inline code highlighting:
+
+```js
+const options = {
+  bypassInlineCode: true,
 };
 ```
 

--- a/examples/next/src/app/index.mdx
+++ b/examples/next/src/app/index.mdx
@@ -94,6 +94,7 @@ Inline ANSI: `> Local: [0;36mhttp://localhost:[0;36;1m3000[0;36m/[0m{:ansi}`
   - [grid](#grid)
   - [theme](#theme)
   - [keepBackground](#keepbackground)
+  - [bypassInlineCode](#bypassInlineCode)
   - [defaultLang](#defaultlang)
   - [transformers](#transformers)
 - [Meta Strings](#meta-strings)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -172,6 +172,7 @@ export function rehypePrettyCode(
     grid = true,
     theme = 'github-dark-dimmed',
     keepBackground = true,
+    bypassInlineCode = false,
     defaultLang = '',
     tokensMap = {},
     filterMetaString = (v) => v,
@@ -230,7 +231,7 @@ export function rehypePrettyCode(
 
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: <explanation>
     visit(tree, 'element', (element, _, parent) => {
-      if (isInlineCode(element, parent)) {
+      if (isInlineCode(element, parent, bypassInlineCode)) {
         const textElement = element.children[0];
         if (!isText(textElement)) return;
         const value = textElement.value;
@@ -275,7 +276,7 @@ export function rehypePrettyCode(
 
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: <explanation>
     visit(tree, 'element', (element, _, parent) => {
-      if (isInlineCode(element, parent)) {
+      if (isInlineCode(element, parent, bypassInlineCode)) {
         const textElement = element.children[0];
         if (!isText(textElement)) return;
         const value = textElement.value;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,6 +22,7 @@ export interface Options {
   grid?: boolean;
   theme?: Theme | Record<string, Theme>;
   keepBackground?: boolean;
+  bypassInlineCode?: boolean;
   defaultLang?: string | { block?: string; inline?: string };
   tokensMap?: Record<string, string>;
   transformers?: Array<ShikiTransformer>;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -20,7 +20,11 @@ export function isText(value: ElementContent | null): value is Text {
 export function isInlineCode(
   element: Element,
   parent: Element | Root | undefined,
+  bypass = false,
 ): element is Element {
+  if (bypass) {
+    return false;
+  }
   return (
     (element.tagName === 'code' &&
       isElement(parent) &&

--- a/packages/core/test/fixtures/bypassInlineCode.md
+++ b/packages/core/test/fixtures/bypassInlineCode.md
@@ -4,4 +4,4 @@
 const x = true;
 ```
 
-`const x = true;{bypassInlineCode:true}`
+`const x = true;{:js,bypassInlineCode:true}`

--- a/packages/core/test/fixtures/bypassInlineCode.md
+++ b/packages/core/test/fixtures/bypassInlineCode.md
@@ -1,6 +1,6 @@
 ## Bypass Inline Code
 
-```js bypassInlineCode{true}
+```js
 const x = true;
 ```
 

--- a/packages/core/test/fixtures/bypassInlineCode.md
+++ b/packages/core/test/fixtures/bypassInlineCode.md
@@ -1,0 +1,7 @@
+## Bypass Inline Code
+
+```js bypassInlineCode{true}
+const x = true;
+```
+
+`const x = true;{bypassInlineCode:true}`

--- a/packages/core/test/results/bypassInlineCode.html
+++ b/packages/core/test/results/bypassInlineCode.html
@@ -60,4 +60,4 @@
     data-theme="github-dark"
   ><code data-language="js" data-theme="github-dark" style="display: grid;"><span data-line=""><span style="color:#F97583">const</span><span style="color:#79B8FF"> x</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> true</span><span style="color:#E1E4E8">;</span></span></code></pre>
 </figure>
-<p><code>const x = true;{bypassInlineCode:true}</code></p>
+<p><code>const x = true;{:js,bypassInlineCode:true}</code></p>

--- a/packages/core/test/results/bypassInlineCode.html
+++ b/packages/core/test/results/bypassInlineCode.html
@@ -1,0 +1,63 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  [data-highlighted-line], [data-highlighted-chars] {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>[data-line]::before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
+
+  [data-rehype-pretty-code-figure] code[data-theme*=' '],
+  [data-rehype-pretty-code-figure] code[data-theme*=' '] span {
+    color: var(--shiki-light) !important;
+    background-color: var(--shiki-light-bg) !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    [data-rehype-pretty-code-figure] code[data-theme*=' '],
+    [data-rehype-pretty-code-figure] code[data-theme*=' '] span {
+      color: var(--shiki-dark) !important;
+      background-color: var(--shiki-dark-bg) !important;
+    }
+  }
+
+  .diff.add {
+    background-color: rgba(0, 255, 100, 0.25);
+  }
+  .diff.remove {
+    background-color: rgba(255, 100, 200, 0.35);
+  }
+</style>
+<h2>Bypass Inline Code</h2>
+<figure data-rehype-pretty-code-figure="">
+  <pre
+    style="background-color: #24292e; color: #e1e4e8"
+    tabindex="0"
+    data-language="js"
+    data-theme="github-dark"
+  ><code data-language="js" data-theme="github-dark" style="display: grid;"><span data-line=""><span style="color:#F97583">const</span><span style="color:#79B8FF"> x</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> true</span><span style="color:#E1E4E8">;</span></span></code></pre>
+</figure>
+<p><code>const x = true;{bypassInlineCode:true}</code></p>


### PR DESCRIPTION
Allows bypassing inline code blocks from being transformed by `rehype-pretty-code`.

Config:

```js /rehypePrettyCode/
import { unified } from "unified";
import remarkParse from "remark-parse";
import remarkRehype from "remark-rehype";
import rehypeStringify from "rehype-stringify";
import rehypePrettyCode from "rehype-pretty-code";

async function main() {
  const file = await unified()
    .use(remarkParse)
    .use(remarkRehype)
    .use(rehypePrettyCode, {
      bypassInlineCode: true
    })
    .use(rehypeStringify)
    .process("`const numbers = [1, 2, 3]{:js}`");

  console.log(String(file));
}

main();
```

Input:

~~~md
```js
const x = true;
```

`const x = true;{:js,bypassInlineCode:true}`
~~~

Output:

```html
<figure data-rehype-pretty-code-figure="">
  <pre
    style="background-color: #24292e; color: #e1e4e8"
    tabindex="0"
    data-language="js"
    data-theme="github-dark"
  ><code data-language="js" data-theme="github-dark" style="display: grid;"><span data-line=""><span style="color:#F97583">const</span><span style="color:#79B8FF"> x</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> true</span><span style="color:#E1E4E8">;</span></span></code></pre>
</figure>
<p><code>const x = true;{:js,bypassInlineCode:true}</code></p>
```