### PR TITLE
fix: error in showLineNumbers example

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -485,11 +485,11 @@ Add a caption underneath your code block, with text inside double quotes (`""`):
 CSS counters can be used to add line numbers.
 
 ```css {2,6-7}
-code {
+code[data-line-numbers] {
   counter-reset: line;
 }
 
-code > [data-line]::before {
+code[data-line-numbers] > [data-line]::before {
   counter-increment: line;
   content: counter(line);
 


### PR DESCRIPTION
The example css did not work for conditional showLineNumbers.

Used the css from the website that shows the working example.

Line 75-83 (example i used)
https://github.com/rehype-pretty/rehype-pretty-code/blob/master/examples/astro/src/globals.css

Old PR
https://github.com/rehype-pretty/rehype-pretty-code/pull/203

Testimonial
https://github.com/rehype-pretty/rehype-pretty-code/pull/203#issuecomment-2274978414