### PR TITLE
fix(docs): code tag style

### DIFF
--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -76,6 +76,7 @@ pre > code {
    * https://github.com/withastro/starlight/blob/main/packages/starlight/style/markdown.css#L94
    */
   counter-reset: line !important;
+  overflow-x: auto !important;
 }
 
 figcaption {


### PR DESCRIPTION
Fixes: #240 

The document was created using astro and starlight unsets some styles. So, I fixed invalid `overflow-x: auto` that should have been styled in the code tag, using `!important`.

![スクリーンショット 2024-08-28 21 19 09](https://github.com/user-attachments/assets/43f73921-bb69-40a3-874c-a78cef9e43c9)
