### PR TITLE
docs(page:home): remove unneeded imports

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -166,7 +166,6 @@ Ensure your `unified{:.string}` version is compatible.
 The following example shows how to use this package with Next.js.
 
 ```js title="next.config.mjs"
-import fs from "node:fs";
 import nextMDX from "@next/mdx";
 import rehypePrettyCode from "rehype-pretty-code";
 


### PR DESCRIPTION
Removed an unnecessary import statement from an example Next.js config file in the home page.