### PR TITLE
use getSingletonHighlighter

### DIFF
--- a/.changeset/cool-carpets-suffer.md
+++ b/.changeset/cool-carpets-suffer.md
@@ -1,0 +1,5 @@
+---
+"rehype-pretty-code": patch
+---
+
+fix: use `getSingletonHighlighter` to avoid deprecated (since v2) Shiki API

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ import type { Options, Theme, CharsHighlighterOptions } from './types';
 import {
   type Highlighter,
   type CodeToHastOptions,
-  getHighlighter as defaultGetHighlighter,
+  getSingletonHighlighter as defaultGetHighlighter,
 } from 'shiki';
 import { visit } from 'unist-util-visit';
 import { toString as hastToString } from 'hast-util-to-string';


### PR DESCRIPTION
The `getHighlighter` function has been deprecated and leads to memory issues from what I read.

Closes #255