### PR TITLE
ci: migrate npm publish to OIDC

### DIFF
--- a/.changeset/late-mice-think.md
+++ b/.changeset/late-mice-think.md
@@ -2,4 +2,4 @@
 "rehype-pretty-code": patch
 ---
 
-Republish with the fixed npm OIDC trusted publishing workflow.
+chore: fix npm OIDC trusted publishing workflow

--- a/.changeset/late-mice-think.md
+++ b/.changeset/late-mice-think.md
@@ -1,0 +1,5 @@
+---
+"rehype-pretty-code": patch
+---
+
+Republish with the fixed npm OIDC trusted publishing workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
-          node-version: '24.x'
+          # v24.14.0 bundles npm 11.9.0; ^ keeps newer 24.x while enforcing this minimum baseline.
+          node-version: '^24.14.0'
           registry-url: 'https://registry.npmjs.org'
 
       - name: 'Install Dependencies'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
-          node-version: 'lts/*'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Install npm >= 11.5.1 (required for OIDC publishing)
-        run: npm install -g npm@^11.5.1
 
       - name: 'Install Dependencies'
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install npm >= 11.5.1 (required for OIDC publishing)
+        run: npm install -g npm@^11.5.1
+
       - name: 'Install Dependencies'
         run: pnpm install --frozen-lockfile
 
@@ -82,7 +85,7 @@ jobs:
           commit: "[ci] release"
           title: "[ci] release"
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Workaround for changesets/action requiring this var to be set.
+          # OIDC trusted publishing does not use an npm token secret.
+          NPM_TOKEN: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
-          # v24.14.0 bundles npm 11.9.0; ^ keeps newer 24.x while enforcing this minimum baseline.
+          # Required for npm OIDC trusted publishing (npm >= 11.5.1), while staying on Node 24.
           node-version: '^24.14.0'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Summary
- migrate release workflow away from npm token secrets
- install npm >= 11.5.1 for trusted publishing support
- keep changesets workaround with empty NPM_TOKEN

## Notes
- aligns with recent OIDC migration pattern used in floating-ui
