### PR TITLE
fix(core): prevent infinite loop in inline highlighting for repeated multi-token patterns

### DIFF
--- a/.changeset/tidy-carrots-highlight.md
+++ b/.changeset/tidy-carrots-highlight.md
@@ -1,0 +1,5 @@
+---
+"rehype-pretty-code": patch
+---
+
+fix: prevent an infinite loop in inline character highlighting when a pattern matches text that spans multiple syntax tokens and occurs more than once on the same line (#185)

--- a/packages/core/src/chars/charsHighlighter.ts
+++ b/packages/core/src/chars/charsHighlighter.ts
@@ -26,12 +26,19 @@ export function charsHighlighter(
   const { ranges = [] } = options;
   const textContent = hastToString(element);
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: char matching is inherently branchy
   charsList.forEach((chars, index) => {
     if (chars && textContent?.includes(chars)) {
       let textContent = hastToString(element);
       let startIndex = 0;
 
       while (textContent.includes(chars)) {
+        // Snapshot the remaining text so we can bail out if an iteration
+        // fails to make progress. The recomputed `textContent` excludes
+        // already-highlighted nodes, so a productive iteration always makes
+        // it strictly shorter; if it does not shrink, no occurrence was
+        // consumed and continuing would loop forever.
+        const previousTextContent = textContent;
         const currentCharsRange = ranges[index] || [];
         const id = `${chars}-${index}`;
 
@@ -79,6 +86,10 @@ export function charsHighlighter(
             }
           })
           .join('');
+
+        // Safety guard: if the remaining text did not shrink, this iteration
+        // consumed nothing, so stop instead of spinning forever.
+        if (textContent.length >= previousTextContent.length) break;
       }
     }
   });

--- a/packages/core/src/chars/wrapHighlightedChars.ts
+++ b/packages/core/src/chars/wrapHighlightedChars.ts
@@ -55,6 +55,11 @@ export function wrapHighlightedChars(
     element.properties = element.properties || {};
     element.properties['data-highlighted-chars'] = '';
     element.properties['data-chars-id'] = id;
+    // Mark this wrapped group as visited so it is skipped when the outer
+    // loop rescans for further occurrences of the same chars. Without this,
+    // a match that spans multiple tokens and repeats on the same line is
+    // re-detected here on every iteration, so the loop never terminates.
+    element.properties['rehype-pretty-code-visited'] = '';
     element.tagName = 'mark';
     onVisitHighlightedChars?.(element as CharsElement, id);
   } else {

--- a/packages/core/test/fixtures/highlightCharsMultiTokenRepeat.md
+++ b/packages/core/test/fixtures/highlightCharsMultiTokenRepeat.md
@@ -1,0 +1,23 @@
+# Highlight chars spanning multiple tokens, repeated
+
+A pattern whose match spans multiple syntax-highlighting tokens and
+occurs more than once on the same line should highlight every
+occurrence without hanging (see issue #185).
+
+/Math.sin/
+
+```js /Math.sin/
+const s = Math.sin(x) + Math.sin(y);
+```
+
+/c.json/
+
+```js /c.json/
+c.json(); c.json();
+```
+
+/'a/
+
+```rust /'a/
+fn f<'a, 'b>(x: &'a str) -> &'a str { x }
+```

--- a/packages/core/test/results/highlightCharsMultiTokenRepeat.html
+++ b/packages/core/test/results/highlightCharsMultiTokenRepeat.html
@@ -1,0 +1,86 @@
+
+<style>
+  html {
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+  }
+  body {
+    margin: 30px auto;
+    max-width: 800px;
+  }
+  pre {
+    padding: 16px;
+  }
+  span > code {
+    background: black;
+    padding: 4px;
+  }
+  [data-highlighted-line], [data-highlighted-chars] {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  code[data-line-numbers] {
+    counter-reset: line;
+  }
+  code[data-line-numbers]>[data-line]::before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1rem;
+    margin-right: 2rem;
+    text-align: right;
+    color: gray;
+  }
+
+  [data-rehype-pretty-code-figure] code[data-theme*=' '],
+  [data-rehype-pretty-code-figure] code[data-theme*=' '] span {
+    color: var(--shiki-light) !important;
+    background-color: var(--shiki-light-bg) !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    [data-rehype-pretty-code-figure] code[data-theme*=' '],
+    [data-rehype-pretty-code-figure] code[data-theme*=' '] span {
+      color: var(--shiki-dark) !important;
+      background-color: var(--shiki-dark-bg) !important;
+    }
+  }
+
+  .diff.add {
+    background-color: rgba(0, 255, 100, 0.25);
+  }
+  .diff.remove {
+    background-color: rgba(255, 100, 200, 0.35);
+  }
+</style>
+<h1>Highlight chars spanning multiple tokens, repeated</h1>
+<p>
+  A pattern whose match spans multiple syntax-highlighting tokens and occurs
+  more than once on the same line should highlight every occurrence without
+  hanging (see issue #185).
+</p>
+<p>/Math.sin/</p>
+<figure data-rehype-pretty-code-figure="">
+  <pre
+    style="background-color: #24292e; color: #e1e4e8"
+    tabindex="0"
+    data-language="js"
+    data-theme="github-dark"
+  ><code data-language="js" data-theme="github-dark" style="display: grid;"><span data-line=""><span style="color:#F97583">const</span><span style="color:#79B8FF"> s</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> </span><mark data-highlighted-chars-mark="" data-highlighted-chars="" class="word"><span style="color:#E1E4E8">Math.</span><span style="color:#B392F0">sin</span></mark><span style="color:#E1E4E8">(x) </span><span style="color:#F97583">+</span><span style="color:#E1E4E8"> </span><mark data-highlighted-chars-mark="" data-highlighted-chars="" class="word"><span style="color:#E1E4E8">Math.</span><span style="color:#B392F0">sin</span></mark><span style="color:#E1E4E8">(y);</span></span></code></pre>
+</figure>
+<p>/c.json/</p>
+<figure data-rehype-pretty-code-figure="">
+  <pre
+    style="background-color: #24292e; color: #e1e4e8"
+    tabindex="0"
+    data-language="js"
+    data-theme="github-dark"
+  ><code data-language="js" data-theme="github-dark" style="display: grid;"><span data-line=""><mark data-highlighted-chars-mark="" data-highlighted-chars="" class="word"><span style="color:#E1E4E8">c.</span><span style="color:#B392F0">json</span></mark><span style="color:#E1E4E8">(); </span><mark data-highlighted-chars-mark="" data-highlighted-chars="" class="word"><span style="color:#E1E4E8">c.</span><span style="color:#B392F0">json</span></mark><span style="color:#E1E4E8">();</span></span></code></pre>
+</figure>
+<p>/'a/</p>
+<figure data-rehype-pretty-code-figure="">
+  <pre
+    style="background-color: #24292e; color: #e1e4e8"
+    tabindex="0"
+    data-language="rust"
+    data-theme="github-dark"
+  ><code data-language="rust" data-theme="github-dark" style="display: grid;"><span data-line=""><span style="color:#F97583">fn</span><span style="color:#B392F0"> f</span><span style="color:#E1E4E8">&#x3C;</span><mark data-highlighted-chars-mark="" data-highlighted-chars="" class="word"><span style="color:#E1E4E8">'</span><span style="color:#B392F0">a</span></mark><span style="color:#E1E4E8">, '</span><span style="color:#B392F0">b</span><span style="color:#E1E4E8">>(x</span><span style="color:#F97583">:</span><span style="color:#F97583"> &#x26;</span><mark data-highlighted-chars-mark="" data-highlighted-chars="" class="word"><span style="color:#E1E4E8">'</span><span style="color:#B392F0">a</span></mark><span style="color:#B392F0"> str</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">-></span><span style="color:#F97583"> &#x26;</span><mark data-highlighted-chars-mark="" data-highlighted-chars="" class="word"><span style="color:#E1E4E8">'</span><span style="color:#B392F0">a</span></mark><span style="color:#B392F0"> str</span><span style="color:#E1E4E8"> { x }</span></span></code></pre>
+</figure>


### PR DESCRIPTION
Fixes #185

## Summary

Inline word highlighting (the ` ```lang /pattern/ ` meta syntax) could enter a
**synchronous infinite loop** — pegging a CPU core and never returning — for a
specific but not-uncommon input. This makes the whole `unified` build hang.

## Trigger condition

The loop happens when **both** of these are true:

1. The highlight pattern matches text that spans **more than one Shiki token**
   (i.e. the matched string contains a character such as `.`, a space, or a
   lifetime `'`, which Shiki renders as separate `<span>` elements), and
2. that match occurs **two or more times on the same line**.

A single occurrence of a multi-token match works fine, and a repeated
single-token match (e.g. `/Math/` twice) works fine — only the *combination*
above hangs.

Minimal reproduction:

````md
```js /Math.sin/
const s = Math.sin(x) + Math.sin(y);
```
````

Other examples that hang: `/c.json/` twice, or the Rust lifetime `/'a/` from
the original issue report.

## Root cause

In `packages/core/src/chars/charsHighlighter.ts`, the highlighting loop repeats
`getElementsToHighlight` + `wrapHighlightedChars` while the recomputed
`textContent` still contains the pattern. Nodes that have already been
highlighted are excluded from that recomputed `textContent` in two ways: they
carry either `data-highlighted-chars-mark` or `rehype-pretty-code-visited`.

When a match spans multiple tokens, `wrapHighlightedChars` wraps those tokens in
a new `<mark>` element but — unlike the single-token branch — it never set
`rehype-pretty-code-visited` on that wrapper. As a result:

- The wrapper's text still equals the pattern, so on the next iteration
  `getElementsToHighlight` re-discovers the *already-wrapped* group.
- `wrapHighlightedChars` is then called with that single `<mark>`, whose first
  child is a `<span>` (not a text node), so the single-element branch bails out
  early and nothing changes.
- The recomputed `textContent` still contains the pattern (from the *second*
  occurrence), so the `while` condition stays true forever.

With only one occurrence this never surfaces, because after the first wrap the
recomputed `textContent` no longer contains the pattern and the loop exits
before the wrapper is re-scanned.

## Fix

1. **Root-cause fix** — in `wrapHighlightedChars.ts`, mark the multi-token
   `<mark>` group with `rehype-pretty-code-visited` (mirroring what the
   single-token branch already does). The group is then skipped on subsequent
   scans, the loop makes progress, and **every** occurrence is highlighted
   correctly. The attribute is cleared at the end of `charsHighlighter` exactly
   like the single-token case, so it does not leak into the output HTML.

2. **Defense-in-depth guard** — in `charsHighlighter.ts`, break the loop if an
   iteration fails to make progress. The recomputed `textContent` excludes
   already-highlighted nodes, so a productive iteration always makes it strictly
   shorter; if it does not shrink, no occurrence was consumed and the loop is
   stopped. This guarantees termination even against any future edge case in the
   matching helpers.

## Tests

Added a regression fixture, `highlightCharsMultiTokenRepeat.md`, covering
repeated multi-token matches in JS (`/Math.sin/`, `/c.json/`) and the Rust
lifetime case (`/'a/`) from the issue. On the previous code this fixture hangs
the entire test run; with the fix it highlights all occurrences (2 + 2 + 3 = 7
groups) and the full suite passes.
